### PR TITLE
use version number for installation also in the RedHat repo install case

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -13,7 +13,7 @@ metricbeat_repo_gpgkey: https://artifacts.elastic.co/GPG-KEY-elasticsearch
 metricbeat_baseurl: "https://download.elastic.co/beats/metricbeat"
 
 metricbeat_packages:
-  - "metricbeat"
+  - "metricbeat{{ (metricbeat_upgrade) | ternary('', '-' + metricbeat_version) }}"
 
 #metricbeat_defaults_cfg: /etc/sysconfig/metricbeat
 


### PR DESCRIPTION
Only the installation using url (not using yum repo ```metricbeat_use_repo: false```) was able to specify the version number.
Now it use the version number only if ```metricbeat_upgrade: false```. 
If ```metricbeat_upgrade: true``` and ```metricbeat_use_repo: true``` it will install the latest version